### PR TITLE
feature: add support to linux arm/v8

### DIFF
--- a/.github/workflows/lib_push_image.yml
+++ b/.github/workflows/lib_push_image.yml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: dev/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8
           push: true
           tags: ${{ inputs.tags }}
           cache-from: ${{ inputs.cache-from }}


### PR DESCRIPTION
Hey team,

Tried installing Surface on a M1 chip and got this error:
```
github.com/surface-security/surface ‹main› » docker-compose -f dev/docker-compose-in-a-box.yml up
[+] Running 0/11
 ⠼ mysql Pulling                                                                                                                                                                                              2.5s
 ⠼ nginx Pulling                                                                                                                                                                                              2.5s
   ⠋ 3aa4d0bbde19 Downloading    [======>                                            ]    392kB/2.813MB                                                                                                       1.0s
   ⠋ 91a0d98ef348 Downloading    [>                                                  ]  73.62kB/7.341MB                                                                                                       1.0s
   ⠋ acdff1cb5e67 Download complete                                                                                                                                                                           1.0s
   ⠋ dfe2157c7506 Waiting                                                                                                                                                                                     1.0s
   ⠋ 0cddbe0663dc Waiting                                                                                                                                                                                     1.0s
   ⠋ 2410dd56c3ee Waiting                                                                                                                                                                                     1.0s
   ⠋ 9801baac913b Waiting                                                                                                                                                                                     1.0s
   ⠋ c8ddb12bc806 Waiting                                                                                                                                                                                     1.0s
   ⠋ 025fd5a407e0 Pulling fs layer                                                                                                                                                                            1.0s
no matching manifest for linux/arm64/v8 in the manifest list entries
```

Both nginx and MySQL images support `arm/v8` officially, so I thought we needed to upgrade our ghcr. However, I am not sure if we should drop `arm/v7` or if we should maintain support for it. Is there anything using it or has everything been replaced with arm/v8? In fact, neither nginx or MySQL refer to v7, so this change should probably be a drop-in replacement instead.

Cheers,