### PR TITLE
Drop support for arm v7 and upgrade MySQL version tags

### DIFF
--- a/.github/workflows/lib_push_image.yml
+++ b/.github/workflows/lib_push_image.yml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: dev/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ inputs.tags }}
           cache-from: ${{ inputs.cache-from }}

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
         libldap2-dev \
         libsasl2-dev \
         git \
+        libpq-dev \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /wheels

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -22,11 +22,6 @@ RUN apt-get update \
 WORKDIR /wheels
 COPY --from=requirements /requirements_full.txt .
 
-ARG TARGETPLATFORM
-# arm/v7 debian buster has no cryptography wheel available, so it tries to build it (and fails)
-# use piwheels wheel repo to avoid building it
-RUN [ "$TARGETPLATFORM" != "linux/arm/v7" ] || printf "[global]\nextra-index-url=https://www.piwheels.org/simple" > /etc/pip.conf
-
 RUN pip wheel -w /wheels -r requirements_full.txt
 
 ############################################################################

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -13,11 +13,11 @@ FROM python:3.9-slim-buster as builder
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \
         libmariadbclient-dev \
+        libpq-dev \
         build-essential \
         libldap2-dev \
         libsasl2-dev \
         git \
-        libpq-dev \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /wheels

--- a/dev/docker-compose-dev.yml
+++ b/dev/docker-compose-dev.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   mysql:
-    image: mysql:8.0.23
+    image: mysql:8.0.30
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_general_ci

--- a/dev/docker-compose-in-a-box.yml
+++ b/dev/docker-compose-in-a-box.yml
@@ -66,7 +66,7 @@ services:
       - ./nginx.template.conf:/etc/nginx/templates/default.conf.template:ro
 
   mysql:
-    image: mysql:8.0.23
+    image: mysql:8.0.30
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_general_ci


### PR DESCRIPTION
Based off #27 and the source code (reference below), `linux/arm/v7` == `linux/arm` and `linux/arm64/v8` == `linux/arm64`. Therefore, this change reduces the clutter when defining the supported platforms.

Ref: https://github.com/containerd/containerd/blob/v1.4.3/platforms/database.go#L83