### PR TITLE
Add PAT permissions to write to packages

### DIFF
--- a/.github/workflows/lib_test_image.yml
+++ b/.github/workflows/lib_test_image.yml
@@ -1,5 +1,8 @@
 name: test image
 
+permissions:
+  packages: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
According to the docs (see below), we can specify we can use the
`permission` keyword to modify the `GITHUB_TOKEN` granted privileges.
This should help dependabot being able to push to the package registry
because we need this for caching purposes (we're caching things in some
stages to speed up the pipeline).

Docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions