### PR TITLE
Adds active=True to scanner inputs

### DIFF
--- a/surface/scanners/inputs/base.py
+++ b/surface/scanners/inputs/base.py
@@ -1,7 +1,6 @@
 __CACHE__ = {}
 from abc import ABCMeta
 
-
 CHOICES = []
 
 

--- a/surface/scanners/inputs/ips.py
+++ b/surface/scanners/inputs/ips.py
@@ -1,5 +1,6 @@
-from .base import BaseInput
 from dns_ips import models
+
+from .base import BaseInput
 
 
 class IPs(BaseInput):

--- a/surface/scanners/inputs/ips_hosts.py
+++ b/surface/scanners/inputs/ips_hosts.py
@@ -1,4 +1,5 @@
 import itertools
+
 from . import hosts, ips
 from .base import BaseInput
 

--- a/surface/scanners/inputs/livehosts.py
+++ b/surface/scanners/inputs/livehosts.py
@@ -3,7 +3,6 @@ import logging
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.utils import timezone
-
 from scanners import models
 
 from .base import BaseInput
@@ -17,6 +16,7 @@ class LiveIPsHosts(BaseInput):
 
     def _queryset(self, ports, tag_filter):
         return models.LiveHost.objects.filter(
+            active=True,
             host__any__tags__name=tag_filter,
             last_seen__gte=timezone.now() - timezone.timedelta(days=7),
             port__in=ports,


### PR DESCRIPTION
Ensures only active assets are selected as scanner inputs. This attempts to smooth out the scanner experiencing by not scanning deprecated or inactive assets, causing endless timeouts and increasing the duration of the scan.

Part of the changes include `isort` works.