### PR TITLE
Remove unnecessary call to requirements.txt

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -4,8 +4,7 @@ FROM --platform=$BUILDPLATFORM ghcr.io/surface-security/compile-requirements:4 a
 # but the remaining stages that only use /requirements_full.txt will not
 
 RUN --mount=type=bind,target=/tmpapp \
-    python /run.py /tmpapp/surface/requirements.txt \
-                   /tmpapp/surface/requirements_prod.txt \
+    python /run.py /tmpapp/surface/requirements_prod.txt \
                    /tmpapp/surface/requirements_psql.txt > /requirements_full.txt
 
 FROM python:3.9-slim-buster as builder

--- a/surface/requirements_prod.txt
+++ b/surface/requirements_prod.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
+
 gunicorn==20.0.4
 eventlet==0.31.0

--- a/surface/requirements_psql.txt
+++ b/surface/requirements_psql.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
+
 psycopg2-binary==2.9.3


### PR DESCRIPTION
All sub-requirement files contain a call to either `requirements.txt` or a file that calls `requirements.txt`. No need to call `requirements.txt` directly.