### PR TITLE
Add wheel to core dependencies

### DIFF
--- a/surface/requirements.txt
+++ b/surface/requirements.txt
@@ -12,6 +12,7 @@ django-nested-admin==3.3.2
 django-daterangefilter==1.0.0
 django-jsoneditor==0.1.6
 netaddr==0.8.0
+wheel==0.38.4
 
 # our own
 django-surface-theme==0.0.8


### PR DESCRIPTION
Although `wheel` is not standard in a Python installation, it is a packaging standard and Surface dependencies very often require `wheel`. This addition ensures all environments will have `wheel` available to build the remaining dependencies.