### PR TITLE
Upgrade Django to 3.2.16

### DIFF
--- a/surface/requirements.txt
+++ b/surface/requirements.txt
@@ -1,5 +1,5 @@
 # Core Libraries
-Django==3.2.12
+Django==3.2.16
 django-admin-rangefilter==0.6.1
 django-after-response==0.2.2
 django-object-actions==2.0.0


### PR DESCRIPTION
Replace #62 from @dependabot because security alerts do not respect `pull-requests-branch-name.separator` option.

Ref: https://github.com/dependabot/dependabot-core/issues/4940