### PR TITLE
Upgrade actions to latest versions

### DIFF
--- a/.github/workflows/lib_push_image.yml
+++ b/.github/workflows/lib_push_image.yml
@@ -17,11 +17,11 @@ jobs:
   doit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to GHCR
         uses: docker/login-action@v1 
         with:
@@ -29,7 +29,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: dev/Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/lib_test_cleanup.yml
+++ b/.github/workflows/lib_test_cleanup.yml
@@ -7,7 +7,7 @@ jobs:
   cleanup_artifact:
     runs-on: ubuntu-latest
     steps:
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: surface-tests
           failOnError: false

--- a/.github/workflows/lib_test_image.yml
+++ b/.github/workflows/lib_test_image.yml
@@ -14,18 +14,18 @@ jobs:
   doit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to GHCR
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: dev/Dockerfile
           platforms: linux/amd64
@@ -36,7 +36,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}-builder-cache:${{ github.ref_name }}-amd64,mode=max
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: surface-tests
           path: /tmp/myimage.tar

--- a/.github/workflows/lib_tests.yml
+++ b/.github/workflows/lib_tests.yml
@@ -7,10 +7,10 @@ jobs:
   style:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9, 3.11]
         database:
         - db: mysql
           url: mysql://root:root@127.0.0.1:8877/surface
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Download artifacts (Docker images) from previous workflows
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: surface-tests
           path: /tmp
@@ -70,7 +70,7 @@ jobs:
                      ghcr.io/${{ github.repository }}:${{ github.ref_name }} \
                      sh -c 'pip install -r requirements_test.txt && pytest -n4 --cov --cov-report=xml:/report/coverage.xml'
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           # do not fail ci for now - https://github.com/codecov/codecov-action/issues/557#issuecomment-1073777427


### PR DESCRIPTION
Unsure if this will solve the push problems we are having but at least we get the latest pieces to work with.
In a future review, these versions should be set to a specific commit hash.

Docs: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions