### PR TITLE
misc: upgrade django-nested-admin dependency

### DIFF
--- a/surface/requirements.txt
+++ b/surface/requirements.txt
@@ -8,7 +8,7 @@ django-restful-admin==1.1.3
 djangorestframework-queryfields==1.0.0
 django-filter==2.4.0
 django-import-export==2.5.0
-django-nested-admin==3.3.2
+django-nested-admin==3.4.0
 django-daterangefilter==1.0.0
 django-jsoneditor==0.1.6
 netaddr==0.8.0


### PR DESCRIPTION
Mostly to enjoy support for Django 3.2 and replace all `url(r'^...` with the newer `re_path(r'...`

Refs:
- https://github.com/theatlantic/django-nested-admin/issues/195
- https://github.com/theatlantic/django-nested-admin/commit/0b8da05430da2196aea350fac340832ded1b5299#diff-a36e79ff9d1d74c17c667e99d23ac920f5f37f16e523d1cd027e81a5d59370c3