### PR TITLE
e2e: add end-to-end testing

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -43,3 +43,7 @@ jobs:
   testscleanup:
    needs: tests
    uses: ./.github/workflows/test_cleanup.yml
+
+  integration:
+    needs: [tests, testscleanup]
+    uses: ./.github/workflows/integration.yml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,19 @@
+name: integration testing
+
+on:
+  workflow_call:
+
+jobs:
+  doit:
+    runs-on: ubuntu-latest
+    services:
+      selenium:
+        image: selenium/standalone-chrome
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set-up environment
+        run: pip install -r surface/requirements_test.txt
+
+      - name: Run test suite
+        run: pytest -v e2e

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 /build
 /dist
 /env
-local.env
+*local.env
 *.retry
 *.sqlite3-journal
 *.swp

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,37 @@
+# End-To-End Integration Tests
+
+This folder contains end-to-end integration tests for the Surface project. The suite should be kept simple and minimal 
+as its main purpose is to ensure minimum functionality of the UI, either in dependency upgrade scenarios or in feature 
+changes, bug fixes, and so on.
+
+The ultimate goal for this suite is to have added validations that any change does not cause backward incompatibilities. 
+Everytime there is a breaking change, we can opt to write a regression test to ensure it does not happen again.
+
+Tests run in headless mode, so you will not see the browser effectively performing the actions. For debugging purposes, 
+you can disable the `headless` option in the custom pytest fixture `setup_cfg` in `conftest.py` and add Python's `pdb` in 
+between to check the actions and watch the application behave.
+
+Another feature of this suite is that most of the setup is handled in Python code (in this case, it's mostly about `pytest` 
+fixtures), so there are no external dependencies and it should be kept this way.
+
+## Running Locally
+
+To run the above test suite locally, you need to install the test dependencies and call pytest from the project root dir:
+- `pip install -r surface/requirements_test.txt` (preferably from a specific Python environment);
+- Install the Selenium webdriver(s) for the chosen browser(s): https://www.selenium.dev/downloads/
+- `pytest -v e2e`
+
+Pytest setup considers invoking directory as the root, which is needed to call some of the commands during the setup. 
+This is the case for `run_dkron`, which starts the Dkron server in the background.
+
+The test suite does not need any `local.env` or environment variables, as things are hardcoded for simplicity. Any need 
+to tweak the tweaks, configuration-wise, should be done by adjusting the `settings` module in the `conftest.py`.
+
+
+## Running in CI
+
+The test suite contains a custom pytest fixture that loads the necessary environment for the corresponding test. The 
+procedure to run these tests in your CI system is pretty much the same as [Running Locally](#running-locally): install 
+test dependencies, install selenium webdriver (or if on GitHub use the action with all this prepared for you - 
+see [`./github/workflows/integration.yml`](./github/workflows/integration.yml)), and run 
+pytest from the project root.

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,81 @@
+import subprocess
+import time
+from dataclasses import dataclass
+
+import pytest
+from django.contrib.auth import get_user_model
+from scanners.models import ScannerImage
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.webdriver import WebDriver
+
+
+@dataclass
+class Config:
+    username: str
+    password: str
+    driver: WebDriver
+
+
+def setup_config(username: str, password: str) -> Config:
+    opts = Options()
+    opts.add_argument("--incognito")
+    opts.add_argument("--headless")
+    return Config(
+        username=username, password=password, driver=webdriver.Chrome(options=opts)
+    )
+
+
+def prep_users(username: str, password: str):
+    User = get_user_model()
+    User.objects.create_superuser(username=username, password=password)
+
+
+def cleanup_users(username: str):
+    User = get_user_model()
+    User.objects.filter(username=username).delete()
+
+
+@pytest.fixture
+def prep_dkron():
+    p = subprocess.Popen(["surface/manage.py", "run_dkron", "-s"])
+    time.sleep(5)  # puke, but required to start dkron properly
+    yield p
+    p.kill()
+
+
+@pytest.fixture
+def prep_scanners():
+    ScannerImage.objects.update_or_create(
+        name="example", defaults={"image": "ghcr.io/surface-security/scanner-example"}
+    )
+    ScannerImage.objects.update_or_create(
+        name="httpx", defaults={"image": "ghcr.io/surface-security/scanner-httpx"}
+    )
+    ScannerImage.objects.update_or_create(
+        name="nmap", defaults={"image": "ghcr.io/surface-security/scanner-nmap"}
+    )
+    yield
+    ScannerImage.objects.filter(name__in=["example", "httpx", "nmap"]).delete()
+
+
+@pytest.fixture
+def test_cfg(settings):
+    """
+    setupTests is a fixture to setup a generic environment to run the selenium tests.
+    Setup should be comprised of setting up the test configuration (TestConfig) and generating dummy data for the tests.
+    """
+    # Setup env
+    settings.USERNAME = "admin"
+    settings.PASSWORD = "admin"
+    settings.SURF_ALLOWED_HOSTS = "*"
+
+    cfg = setup_config(settings.USERNAME, settings.PASSWORD)
+    prep_users(settings.USERNAME, settings.PASSWORD)
+
+    # Run tests
+    yield cfg
+
+    # Teardown
+    cfg.driver.close()
+    cleanup_users(settings.USERNAME)

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = surface.settings_test
+pythonpath = . ../surface
+addopts = --create-db -v -m webtest
+markers =
+    webtest: mark a test for webtests

--- a/e2e/test_dkron.py
+++ b/e2e/test_dkron.py
@@ -1,0 +1,52 @@
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+TEST_IO = {
+    "name": "test",
+    "schedule": "@manually",
+    "command": "echo 1",
+    "description": "test job",
+}
+
+
+@pytest.mark.webtest
+def test_dkron_admin_views(prep_dkron, test_cfg, live_server):
+    test_cfg.driver.get(f"{live_server.url}/login/")
+    assert "Login" in test_cfg.driver.title
+
+    test_cfg.driver.find_element(by=By.ID, value="id_username").send_keys(
+        test_cfg.username
+    )
+    test_cfg.driver.find_element(by=By.ID, value="id_password").send_keys(
+        f"{test_cfg.password}"
+    )
+    test_cfg.driver.find_element(
+        by=By.XPATH, value='//button[text()="Submit"]'
+    ).send_keys(Keys.ENTER)
+
+    assert "Home | Surface" == test_cfg.driver.title
+
+    test_cfg.driver.get(f"{live_server.url}/dkron/job/add/")
+    assert "Add job | Surface" == test_cfg.driver.title
+
+    test_cfg.driver.find_element(by=By.ID, value="id_name").send_keys(TEST_IO["name"])
+    test_cfg.driver.find_element(by=By.ID, value="id_schedule").send_keys(
+        TEST_IO["schedule"]
+    )
+    test_cfg.driver.find_element(by=By.ID, value="id_command").send_keys(
+        TEST_IO["command"]
+    )
+    test_cfg.driver.find_element(by=By.ID, value="id_description").send_keys(
+        TEST_IO["description"]
+    )
+    test_cfg.driver.find_element(by=By.ID, value="id_use_shell").click()
+    test_cfg.driver.find_element(by=By.ID, value="id_notify_on_error").click()
+
+    test_cfg.driver.find_element(by=By.NAME, value="_save").send_keys(Keys.ENTER)
+
+    test_cfg.driver.get(f"{live_server.url}/dkron/job")
+    assert "Select job to change | Surface" == test_cfg.driver.title
+
+    for k, v in TEST_IO.items():
+        assert v == test_cfg.driver.find_element(by=By.CLASS_NAME, value=f"field-{k}").text

--- a/e2e/test_login.py
+++ b/e2e/test_login.py
@@ -1,0 +1,21 @@
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+
+@pytest.mark.webtest
+def test_login(live_server, test_cfg):
+    test_cfg.driver.get(f"{live_server.url}/login/")
+    assert "Login" in test_cfg.driver.title
+
+    test_cfg.driver.find_element(by=By.ID, value="id_username").send_keys(
+        test_cfg.username
+    )
+    test_cfg.driver.find_element(by=By.ID, value="id_password").send_keys(
+        f"{test_cfg.password}"
+    )
+    test_cfg.driver.find_element(
+        by=By.XPATH, value='//button[text()="Submit"]'
+    ).send_keys(Keys.ENTER)
+
+    assert "Home | Surface" == test_cfg.driver.title

--- a/surface/requirements_test.txt
+++ b/surface/requirements_test.txt
@@ -6,3 +6,6 @@ pytest-django==4.5.2
 pytest-xdist==3.2.1
 pytest-socket==0.4.0
 responses==0.22.0
+
+# for integration testing
+selenium==4.8.3


### PR DESCRIPTION
This change includes:
- The Selenium tests (obviously) 
    - These tests were written to work against live hosts, which might include a given instance users can configure on their own. 
    - These tests are configurable through `pytest` fixtures. These fixtures set settings as needed.