### PR TITLE
feat: install django-impersonator

### DIFF
--- a/surface/requirements.txt
+++ b/surface/requirements.txt
@@ -22,6 +22,7 @@ django-dkron==1.1.0
 django-slack-processor==0.0.4
 django-olympus==0.0.3
 django-environ-ppb[vault]==1.0.0
+django-impersonator==0.0.1
 
 mysqlclient==2.0.3
 tqdm==4.48.1  # for core_utils that is not really a app/package ..?

--- a/surface/surface/settings.py
+++ b/surface/surface/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 from pathlib import Path
+
 import ppbenviron
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -29,6 +30,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'impersonate',
     'surfapp',
     'dkron',
     'notifications',
@@ -48,6 +50,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'impersonate.middleware.ImpersonateMiddleware',
 ]
 
 ROOT_URLCONF = 'surface.urls'
@@ -71,7 +74,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'surface.wsgi.application'
 
-
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
 
@@ -90,7 +92,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
@@ -103,7 +104,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
@@ -126,7 +126,6 @@ if DATABASES['default']['ENGINE'] == 'django.db.backends.mysql':
         DATABASES['default']['TEST'] = {}
     DATABASES['default']['TEST']['CHARSET'] = 'utf8mb4'
     DATABASES['default']['TEST']['COLLATION'] = 'utf8mb4_general_ci'
-
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/

--- a/surface/surfapp/admin.py
+++ b/surface/surfapp/admin.py
@@ -1,5 +1,8 @@
 from django.contrib.admin import site
+from django.contrib.auth import admin
+from impersonate.admin import impersonate_action
 
+admin.UserAdmin.actions.append(impersonate_action)
 
 site.site_title = 'Surface'
 site.site_url = 'https://github.com/surface-security/surface'


### PR DESCRIPTION
Add ability to impersonator non-admin users by admin users, both to work as an example but also to help debug user and group permissions.

----

I was going to also include `django-apitokens` but that is honestly way harder to do because it will require adding `djangorestframework` and stuff. This base project does not use it, so it would be a bit overkill. Better work on the examples available in the `django-apitokens` itself too.