### PR TITLE
misc: rmeove `language_version` `black` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
     rev: 22.10.0
-    language_version: python3.9
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
It's not longer used. Bad copy/paste.

Ref: https://github.com/psf/black/pull/2430