### PR TITLE
feat: add `apitokens` to installed apps

### DIFF
--- a/surface/requirements.txt
+++ b/surface/requirements.txt
@@ -23,6 +23,7 @@ django-slack-processor==0.0.4
 django-olympus==0.0.3
 django-environ-ppb[vault]==1.0.0
 django-impersonator==0.0.1
+django-apitokens==0.0.1
 
 mysqlclient==2.0.3
 tqdm==4.48.1  # for core_utils that is not really a app/package ..?

--- a/surface/surface/settings.py
+++ b/surface/surface/settings.py
@@ -40,6 +40,8 @@ INSTALLED_APPS = [
     'dns_ips',
     'scanners',
     'scanner_baseline',
+    'knox',
+    'apitokens',
 ]
 
 MIDDLEWARE = [
@@ -58,7 +60,8 @@ ROOT_URLCONF = 'surface.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        # surfapp templates required here as well to override `theme` ones (as theme needs to come first in INSTALLED_APPS)
+        # surfapp templates required here as well to override `theme` ones,
+        # (as theme needs to come first in INSTALLED_APPS)
         'DIRS': [BASE_DIR / 'surfapp' / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {

--- a/surface/surfapp/templates/includes/navigation.html
+++ b/surface/surfapp/templates/includes/navigation.html
@@ -1,0 +1,7 @@
+{% extends "includes/navigation.html" %}
+
+{% block menu_options %}
+<div class="dropdown-divider"></div>
+<a class="dropdown-item" href="{% url 'admin:auth_user_change' request.user.pk %}">Profile</a>
+<a class="dropdown-item" href="{% url 'admin:apitokens_mytoken_changelist' %}">API Tokens</a>
+{% endblock %}


### PR DESCRIPTION
Sample configuration to use API Tokens, including theme tweak to include in navigation bar.

Replaces https://github.com/surface-security/django-apitokens/pull/11 