### PR TITLE
dns_ips: Fix broken migration with proper invocation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,4 @@ repos:
     rev: 'v0.0.261'
     hooks:
       - id: ruff
+        args: ["--fix"]

--- a/surface/dns_ips/migrations/0005_deprecate_nameservers.py
+++ b/surface/dns_ips/migrations/0005_deprecate_nameservers.py
@@ -28,7 +28,7 @@ def move_data_over(apps, db_schema):
         obj['nameservers'] = ", ".join(nameservers)
         updated_domains.append(obj)
 
-    domain_mod.objects.bulk_update(updated_domains, ['nameservers'], batch_size=500)
+    domain_mod.objects.bulk_update([domain_mod(**kv) for kv in updated_domains], ['nameservers'], batch_size=500)
 
 
 class Migration(migrations.Migration):
@@ -41,7 +41,9 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='dnsdomain',
             name='nameservers',
-            field=models.TextField(help_text='list of nameservers associated, separated by comma'),
+            field=models.TextField(
+                blank=True, default='', help_text='list of nameservers associated, separated by comma'
+            ),
         ),
         migrations.RunPython(move_data_over, reverse_code=migrations.RunPython.noop),
         migrations.RemoveField(

--- a/surface/dns_ips/models.py
+++ b/surface/dns_ips/models.py
@@ -161,9 +161,6 @@ class DNSDomain(models.Model):
     registration_date = models.DateTimeField(null=True, blank=True, db_index=True)
     expire_date = models.DateTimeField(null=True, blank=True, db_index=True)
     raw_whois = models.TextField(null=True, blank=True)
-    nameservers = models.TextField(
-        default="", blank=True, help_text='list of nameservers associated, separated by comma'
-    )
     # Options for Domain
     register_management_status = models.BooleanField(default=False, db_index=True)
     register_dns_managed = models.BooleanField(default=False, db_index=True)

--- a/surface/dns_ips/models.py
+++ b/surface/dns_ips/models.py
@@ -1,10 +1,8 @@
 import functools
 
+from bulk_update_or_create import BulkUpdateOrCreateQuerySet
 from django.db import models
 from django.utils import timezone
-
-
-from bulk_update_or_create import BulkUpdateOrCreateQuerySet
 
 from core_utils.fields import RangeModel
 
@@ -163,6 +161,9 @@ class DNSDomain(models.Model):
     registration_date = models.DateTimeField(null=True, blank=True, db_index=True)
     expire_date = models.DateTimeField(null=True, blank=True, db_index=True)
     raw_whois = models.TextField(null=True, blank=True)
+    nameservers = models.TextField(
+        default="", blank=True, help_text='list of nameservers associated, separated by comma'
+    )
     # Options for Domain
     register_management_status = models.BooleanField(default=False, db_index=True)
     register_dns_managed = models.BooleanField(default=False, db_index=True)


### PR DESCRIPTION
Hey all.

With live data, the migration breaks down because the field calls were just wrong. Not sure what sort of tests we can create to keep track of these changes.
My suggestion is to (urgently) merge this into main and release a `v1.1.1` containing this fix alone. I can write something in the release notes advising to backup data, revert and reapply migration `0005` in the `dns_ips` apps.

For newcomers this should have no impact at all.