### PR TITLE
misc: Conflicting dependency + issues for psql

### DIFF
--- a/surface/requirements_dev.txt
+++ b/surface/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements_test.txt
 
-black==23.3.0
+black==22.8.0
 django-debug-toolbar==3.7.0
 pre-commit==3.2.2
 pylint==2.17.1

--- a/surface/requirements_dev.txt
+++ b/surface/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements_test.txt
 
-black==22.8.0
+black==23.3.0
 django-debug-toolbar==3.7.0
 pre-commit==3.2.2
 pylint==2.17.1

--- a/surface/requirements_psql.txt
+++ b/surface/requirements_psql.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.6

--- a/surface/scanners/requirements.txt
+++ b/surface/scanners/requirements.txt
@@ -1,5 +1,5 @@
 cffi==1.15.1
-packaging==21.0
+packaging==23.1
 pyOpenSSL==19.1.0
 # docker-py5 requires cryptography higher than OCI
 docker[tls]<5.0.0


### PR DESCRIPTION
Tried a clean start and had issues installing the latest of black, as well as starting a Postgres DB.

Not sure why the tests are not failing with these errors? :( 

# Black

Seems Black==23.3.0 has requirements for `packaging` which is not compliant with other existing dependencies. Let's revert this change so we can continue building the project.

```
ERROR: Cannot install -r surface/requirements.txt (line 13), -r surface/requirements_dev.txt (line 3), -r surface/requirements_test.txt (line 3) and packaging==21.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested packaging==21.0
    django-jsoneditor 0.1.6 depends on packaging
    pytest 7.2.2 depends on packaging
    black 23.3.0 depends on packaging>=22.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

# Postgres issue

```Error: pg_config executable not found.                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                            
      pg_config is required to build psycopg2 from source.  Please add the directory                                                                                                                                                                                                                                                                                                        
      containing pg_config to the $PATH or specify the full executable path with the                                                                                                                                                                                                                                                                                                        
      option:                                                                                                                                                                                 
```
The latest version does not cause this.


