### PR TITLE
fix: add sca to non ignored directories

### DIFF
--- a/dev/Dockerfile-IN-A-BOX.dockerignore
+++ b/dev/Dockerfile-IN-A-BOX.dockerignore
@@ -1,7 +1,9 @@
 # dockerignore to avoid invalidating cache on anything other than requirements changes
 **
 !surface/requirements*.txt
+!surface/sca
 !surface/scanners
 !surface/dns_ips
+!.surface/surface/sca/requirements*.txt
 !.surface/surface/scanners/requirements*.txt
 !.surface/surface/dns_ips/requirements*.txt


### PR DESCRIPTION
This change ensure docker compose does not ignore the `sca` folder and its requirements, whereas without the build fails with the error message below:

Could not open requirements file: [Errno 2] No such file or directory: '/tmpapp/surface/sca/requirements.txt'