### PR TITLE
fix: proper closing Tag object creation

### DIFF
--- a/dev/box_setup.sh
+++ b/dev/box_setup.sh
@@ -30,8 +30,8 @@ EOF
 # create default tags used by default scanner Input
 cat <<EOF | dexec -T surface ./manage.py shell
 from dns_ips.models import Tag
-Tag.objects.update_or_create(name="is_external", defaults={"notes": "Tag used for external DNS and IP assets")
-Tag.objects.update_or_create(name="is_external", defaults={"notes": "Tag used for internal DNS and IP assets")
+Tag.objects.update_or_create(name="is_external", defaults={"notes": "Tag used for external DNS and IP assets"})
+Tag.objects.update_or_create(name="is_external", defaults={"notes": "Tag used for internal DNS and IP assets"})
 EOF
 
 echo done


### PR DESCRIPTION
Replaces #164 as that fork doesn't have the necessary permissions to run the actions.